### PR TITLE
Update minimum version of balanced-match to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "dist"
   ],
   "dependencies": {
-    "balanced-match": "^1.0.0"
+    "balanced-match": "^2.0.0"
   },
   "peerDependencies": {
     "postcss": "^8.1.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.11.6",
     "@babel/cli": "^7.11.6",
+    "@babel/core": "^7.11.6",
     "@babel/preset-env": "^7.11.5",
     "@babel/register": "^7.11.5",
     "eslint": "^7.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1005,6 +1005,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+balanced-match@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
+  integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"


### PR DESCRIPTION
Breaking change is dropping support for older node versions (the versions we check in travis is supported)
https://github.com/juliangruber/balanced-match/releases has full changes.